### PR TITLE
Fix problem with using audit log under cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/build
 /build
 /vendor
 .DS_Store
+/.idea

--- a/src/model/AuditLog.php
+++ b/src/model/AuditLog.php
@@ -67,9 +67,7 @@ class AuditLog extends \atk4\data\Model
      */
     public function getUserInfo()
     {
-        return [
-            'ip' => $_SERVER['REMOTE_ADDR']
-        ];
+        return isset($_SERVER['REMOTE_ADDR']) ? ['ip' => $_SERVER['REMOTE_ADDR']] : [];
     }
 
     /**


### PR DESCRIPTION
When AuditLog is usd under CLI and exception is thrown because `$_SERVER['REMOTE_ADDRS']` is not set.